### PR TITLE
Boxcar notifications + fix for migrate.php

### DIFF
--- a/server/admin/app_name.php
+++ b/server/admin/app_name.php
@@ -95,7 +95,9 @@ if (!$acceptallapps)
         echo "Email notifications not activated!<br/>";
 	if ($push_activated)
         echo "<input type='text' name='pushids' size='25' maxlength='250' placeholder='max. 5 , separated Prowl IDs'/>";
-    else
+    else if ($boxcar_activated)
+		echo "Boxcar notifications set for $boxcar_uid<br/>";
+	else
         echo "Push notifications not activated!";
     echo "</td>";
 	echo "<td><select name='symbolicate'><option value=0 selected>Don't symbolicate</option><option value=1>Symbolicate</option></select>";
@@ -134,7 +136,9 @@ if ($numrows > 0) {
             echo "Email notifications not activated!<br/>";
     	if ($push_activated)
             echo "<input type='text' name='pushids' size='25' maxlength='250' placeholder='max. 5 , separated Prowl IDs' value='".$push."'/>";
-        else
+        else if ($boxcar_activated)
+			echo "Boxcar notifications set for $boxcar_uid<br/>";
+	    else
             echo "Push notifications not activated!";
         echo "</td>";
 		echo "<td><select name='symbolicate' onchange='javascript:document.update".$id.".submit();'>";

--- a/server/admin/migrate.php
+++ b/server/admin/migrate.php
@@ -40,6 +40,8 @@ function end_with_result($result) {
 	return '<html><body>'.$result.'</body></html>'; 
 }
 
+$link = mysql_connect($server, $loginsql, $passsql);
+
 $query = "ALTER TABLE ".$dbgrouptable." ADD COLUMN latesttimestamp BIGINT";
 $result = mysql_query($query) or die(end_with_result('Error in SQL: '.$query));
 

--- a/server/class.boxcar.php
+++ b/server/class.boxcar.php
@@ -1,0 +1,54 @@
+<?php
+// by gpetit, http://help.boxcar.io/discussions/developers/15-php-class-to-send-notification-in-boxcar
+
+	class Boxcar {
+
+		private $username;
+		private $password;
+
+		public function __construct($username = "", $password = "") {
+
+            $this->username		= $username;
+            $this->password		= $password;
+        }
+        
+		public function send($sender, $message) {
+
+			$rdmint = rand();
+			$ch = curl_init();
+			curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+			curl_setopt($ch, CURLOPT_USERPWD, $this->username.':'.$this->password);
+			curl_setopt($ch, CURLOPT_URL, 'https://boxcar.io/notifications');
+			curl_setopt($ch, CURLOPT_POST, 3);
+			curl_setopt($ch, CURLOPT_POSTFIELDS, 'notification[from_screen_name]='.urlencode(stripslashes($sender)).'&notification[message]='.urlencode(stripslashes($message)).($id ? '&notification[from_remote_service_id]='.$rdmint : ''));
+			$return = curl_exec($ch);
+
+			$httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+			curl_close($ch);
+
+			# Invalid username/password
+			if($httpcode == "401"):
+
+				return array("success" => "n",
+							"error" => "Invalid username/password",
+							"error_code" => "401");
+
+			# No application/event defined
+			elseif($httpcode == "400"):
+
+				return array("success" => "n",
+							"error" => "No application/event defined",
+							"error_code" => "400");
+
+			# All ok!
+			endif;			
+
+			return array("success" => "y",
+						"error" => "",
+						"error_code" => "");
+		}
+
+	};
+
+?>

--- a/server/config.php
+++ b/server/config.php
@@ -84,6 +84,10 @@ $push_activated = false;                        // activate push notifications v
 $push_prowlids = '';                            // Up to 5 comma separated prowl api keys which should get the notifications
                                                 // can also be set per app, this is a global setting also effective when acceptallapps is true
 
+$boxcar_activated = true;						// Separate setting for Boxcar, so as to not interfere with Prowl config
+$boxcar_uid = "";								// Boxcar user email
+$boxcar_pwd = "";								// Boxcar password
+
 $mail_activated = true;					        // activate email notifications
 $mail_addresses = '';                           // , separated mail addresses to send notification emails to
                                                 // can also be set per app, this is a global setting also effective when acceptallapps is true

--- a/server/test_setup.php
+++ b/server/test_setup.php
@@ -49,7 +49,18 @@ else
     if (!class_exists('Prowl', false)) echo "FAILED"; else echo "passed";
 }
 echo "<br>";
-		
+
+echo "Boxcar: ";
+$curl_info = curl_version();	// Checks for cURL function and SSL version. Thanks Adrian Rollett!
+if(!function_exists('curl_exec') || empty($curl_info['ssl_version']))
+    echo "FAILED (cURL library missing or does not support SSL)";
+else
+{
+	include('class.boxcar.php');
+    if (!class_exists('Boxcar', false)) echo "FAILED"; else echo "passed";
+}
+echo "<br>";
+
 echo "Database access: ";
 $link = mysql_connect($server, $loginsql, $passsql);
 if ($link === false) echo "FAILED";


### PR DESCRIPTION
Added 1 line to `migrate.php` to connect to the right database.

Also added some rudimentary support for Boxcar. Not much of a PHP guy, so it's pretty hacky. If you want me to change the way I do anything here, let me know, and I will. Basically, just set `boxcar_activated` to true in the config, and then enter your username (email) and password, and then it piggybacks onto the crash reporting methods for prowl. You will need to set up a "Growl or API" service in boxcar to receive the notifications. `class.boxcar.php` was taken from Boxcar's [UserAPIExample repo on GitHub](https://github.com/boxcar/UserApiExample/blob/master/class.boxcar.php).
