### PR TITLE
Fix for DB Migration

### DIFF
--- a/server/admin/migrate.php
+++ b/server/admin/migrate.php
@@ -42,6 +42,8 @@ function end_with_result($result) {
 
 $link = mysql_connect($server, $loginsql, $passsql);
 
+$con = mysql_select_db($base, $link);
+
 $query = "ALTER TABLE ".$dbgrouptable." ADD COLUMN latesttimestamp BIGINT";
 $result = mysql_query($query) or die(end_with_result('Error in SQL: '.$query));
 


### PR DESCRIPTION
Was still having DB migration issues. Turned out to be some stupidity on my part (username/password/database fail), but I also needed to do the `mysql_select()` call in order to get everything working ok. This should be the last fix.
