### PR TITLE
fixed indentation for correct code formatting inside lists

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -150,12 +150,12 @@
 - Add the Apple framework `SystemConfiguration.framework` to your project
 - In your `appDelegate.h` include
 
-      #import "BWQuincyManager.h"
+        #import "BWQuincyManager.h"
 
   and let your appDelegate implement the protocol `BWQuincyManagerDelegate`
 - In your appDelegate applicationDidFinishLaunching function include
 
-      [[BWQuincyManager sharedQuincyManager] setSubmissionURL:@"http://yourserver.com/crash_v200.php"];
+        [[BWQuincyManager sharedQuincyManager] setSubmissionURL:@"http://yourserver.com/crash_v200.php"];
       
 - Done.
 - When testing the connection and a server side error appears after sending a crash log, the error code is printed in the console. Error code values are listed in `BWQuincyManager.h`
@@ -163,33 +163,33 @@
 
 # MAC PROJECT INSTALLATION
 
-- Include `Quincy.framework.framework` into your project
+- Include `Quincy.framework` into your project
 - In your `appDelegate.h` include
 
-      #import <Quincy/BWQuincyManager.h>
+        #import <Quincy/BWQuincyManager.h>
 
 - In your appDelegate.h add the BWQuincyManagerDelegate protocol to your appDelegate
 
-      @interface DemoAppDelegate : NSObject <BWQuincyManagerDelegate> {}
+        @interface DemoAppDelegate : NSObject <BWQuincyManagerDelegate> {}
 
 - In your `appDelegate` change the invocation of the main window to the following structure
 
-    // this delegate method is required
-    - (void) showMainApplicationWindow
-    {
-        // launch the main app window
-        // remember not to automatically show the main window if using NIBs
-        [window makeFirstResponder: nil];
-        [window makeKeyAndOrderFront:nil];
-    }
+        // this delegate method is required
+        - (void) showMainApplicationWindow
+        {
+            // launch the main app window
+            // remember not to automatically show the main window if using NIBs
+            [window makeFirstResponder: nil];
+            [window makeKeyAndOrderFront:nil];
+        }
 
 
-    - (void)applicationDidFinishLaunching:(NSNotification *)note
-    {
-      // Launch the crash reporter task
-      [[BWQuincyManager sharedQuincyManager] setSubmissionURL:@"http://yourserver.com/crash_v200.php"];
-      [[BWQuincyManager sharedQuincyManager] setDelegate:self];
-    }
+        - (void)applicationDidFinishLaunching:(NSNotification *)note
+        {
+          // Launch the crash reporter task
+          [[BWQuincyManager sharedQuincyManager] setSubmissionURL:@"http://yourserver.com/crash_v200.php"];
+          [[BWQuincyManager sharedQuincyManager] setDelegate:self];
+        }
 
 - Done.
 


### PR DESCRIPTION
Hello QuincyKit Team,

I adjusted the indentation depth in the readme file to properly format code blocks in list environments.

Taken from the [Markdown Syntax reference](http://daringfireball.net/projects/markdown/syntax#precode)

> To put a code block within a list item, the code block needs to be indented twice — 8 spaces or two tabs

Hope this helps a bit.

Thanks for your work,
Thomas
