### PR TITLE
Remove report from queue if server could not parse it

### DIFF
--- a/client/iOS/BWQuincyManager.m
+++ b/client/iOS/BWQuincyManager.m
@@ -445,6 +445,7 @@ NSBundle *quincyBundle(void) {
 			
             if (report == nil) {
                 NSLog(@"Could not parse crash report");
+				[fm removeItemAtPath:filename error:&error];
                 continue;
             }
 


### PR DESCRIPTION
Avoids an infinite loop in case of server misconfiguration
