### PR TITLE
Avoiding duplicate exception entries in crash group description field

### DIFF
--- a/server/crash_v200.php
+++ b/server/crash_v200.php
@@ -513,7 +513,9 @@ foreach ($crashes as $crash) {
 
                 if ($desc != "" && $appcrashtext != "") {
     				$desc = str_replace("'", "\'", $desc);
-                    if (strpos($desc, $appcrashtext) === false) {
+					$noAddressDesc = preg_replace('/0x[0-9a-f]+/', '', $desc);
+					$noAddressCrashText = preg_replace('/0x[0-9a-f]+/', '', $appcrashtext);
+                    if (strpos($noAddressDesc, $noAddressCrashText) === false) {
                         $appcrashtext = $desc."\n".$appcrashtext;
                         $query = "UPDATE ".$dbgrouptable." SET description='".$appcrashtext."' WHERE id=".$log_groupid;
                         $result = mysql_query($query) or die(end_with_result('Error in SQL '.$query));


### PR DESCRIPTION
Not adding multiple entries to the crash description field if the description only differs by the hex address of some object.
For example: 
**\* Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[**NSMallocBlock** tryLock]: unrecognized selector sent to instance 0x15d4f0'
**\* Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[**NSMallocBlock** tryLock]: unrecognized selector sent to instance 0x7450f50'
...
