### PR TITLE
Collect and send console logs which were produced just before the application crashed

### DIFF
--- a/client/iOS/BWQuincyManager.h
+++ b/client/iOS/BWQuincyManager.h
@@ -150,6 +150,8 @@ typedef enum CrashReportStatus {
   id <BWQuincyManagerDelegate> _delegate;
   
   BOOL _loggingEnabled;
+  BOOL _appendConsoleLogsToDescription;
+  NSUInteger _consoleLogMaxCount;
   BOOL _showAlwaysButton;
   BOOL _feedbackActivated;
   BOOL _autoSubmitCrashReport;
@@ -198,6 +200,15 @@ typedef enum CrashReportStatus {
 // if YES, states will be logged using NSLog. Only enable this for debugging!
 // if NO, nothing will be logged. (default)
 @property (nonatomic, assign, getter=isLoggingEnabled) BOOL loggingEnabled;
+
+// if YES, console logs of the current process will be appended to crash descriptions and uploaded to the server.
+// Only log entries which were generated just before the crash will be included. 
+// if NO, console logs won't be appended to crash descriptions. (default)
+@property (nonatomic, assign) BOOL appendConsoleLogsToDescription;
+
+// How many most recent log entries should be sent if appendConsoleLogsToDescription is set to YES
+// Default: 50 lines.
+@property (nonatomic, assign) NSUInteger consoleLogMaxCount;
 
 // nil, using the default localization files (Default)
 // set to another string which will be appended to the Quincy localization file name, "Alternate" is another provided text set

--- a/client/iOS/BWQuincyManager.m
+++ b/client/iOS/BWQuincyManager.m
@@ -576,9 +576,10 @@ NSString *BWQuincyLocalize(NSString *stringToken) {
                                                                   processID:report.processInfo.processID
                                                                   timestamp:report.systemInfo.timestamp
                                                               maxEntryCount:self.consoleLogMaxCount];
-          
-          description = [description stringByAppendingString:@"\n\n"];
-          description = [description stringByAppendingString:[logEntries componentsJoinedByString:@"\n"]];
+          if([logEntries count] > 0) {
+              description = [description stringByAppendingString:@"\n\n"];
+              description = [description stringByAppendingString:[logEntries componentsJoinedByString:@"\n"]];
+          }
       }
 
       NSString *crashLogString = [PLCrashReportTextFormatter stringValueForCrashReport:report withTextFormat:PLCrashReportTextFormatiOS];

--- a/client/iOS/BWQuincyManager.m
+++ b/client/iOS/BWQuincyManager.m
@@ -498,24 +498,24 @@ NSString *BWQuincyLocalize(NSString *stringToken) {
     
 	while (NULL != (m = aslresponse_next(r)))
 	{
-		const char *value = asl_get(m, ASL_KEY_SENDER);
-		NSString *sender = (value != NULL) ? [NSString stringWithUTF8String:value] : @"";
+        const char *value = asl_get(m, ASL_KEY_SENDER);
+        NSString *sender = (value != NULL) ? [NSString stringWithUTF8String:value] : @"";
         
         value = asl_get(m, ASL_KEY_PID);
-		NSString *processID = (value != NULL) ? [NSString stringWithUTF8String:value] : @"";
+        NSString *processID = (value != NULL) ? [NSString stringWithUTF8String:value] : @"";
         
         value = asl_get(m, ASL_KEY_MSG);
-		NSString *message = (value != NULL) ? [NSString stringWithUTF8String:value] : @"";
+        NSString *message = (value != NULL) ? [NSString stringWithUTF8String:value] : @"";
         
         value = asl_get(m, "CFLog Local Time");
-		NSString *localizedTime = (value != NULL) ? [NSString stringWithUTF8String:value] : @"";
+        NSString *localizedTime = (value != NULL) ? [NSString stringWithUTF8String:value] : @"";
         
         value = asl_get(m, "CFLog Thread");
-		NSString *threadName = (value != NULL) ? [NSString stringWithUTF8String:value] : @"";
+        NSString *threadName = (value != NULL) ? [NSString stringWithUTF8String:value] : @"";
 
-		NSString *combinedLogEntry = [NSString stringWithFormat:@"%@ %@[%@:%@] %@", localizedTime, sender, processID, threadName, message];
+        NSString *combinedLogEntry = [NSString stringWithFormat:@"%@ %@[%@:%@] %@", localizedTime, sender, processID, threadName, message];
         
-		[logEntries addObject:combinedLogEntry];
+        [logEntries addObject:combinedLogEntry];
 	}
 	aslresponse_free(r);
 	asl_free(q);

--- a/client/iOS/BWQuincyManager.m
+++ b/client/iOS/BWQuincyManager.m
@@ -27,6 +27,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <asl.h>
 #import <CrashReporter/CrashReporter.h>
 #import <SystemConfiguration/SystemConfiguration.h>
 #import <UIKit/UIKit.h>
@@ -88,6 +89,8 @@ NSString *BWQuincyLocalize(NSString *stringToken) {
 @synthesize languageStyle = _languageStyle;
 @synthesize didCrashInLastSession = _didCrashInLastSession;
 @synthesize loggingEnabled = _loggingEnabled;
+@synthesize appendConsoleLogsToDescription = _appendConsoleLogsToDescription;
+@synthesize consoleLogMaxCount = _consoleLogMaxCount;
 
 @synthesize appIdentifier = _appIdentifier;
 
@@ -128,6 +131,8 @@ NSString *BWQuincyLocalize(NSString *stringToken) {
     _languageStyle = nil;
     _didCrashInLastSession = NO;
     _loggingEnabled = NO;
+    _appendConsoleLogsToDescription = NO;
+    _consoleLogMaxCount = 50;  
     
     self.delegate = nil;
     self.feedbackActivated = NO;
@@ -468,6 +473,63 @@ NSString *BWQuincyLocalize(NSString *stringToken) {
   }
 }
 
+- (NSArray *) _fetchConsoleLogEntriesForProcessName:(NSString *)processName
+                                     processID:(NSUInteger)processID
+                                     timestamp:(NSDate *)timestamp
+                                 maxEntryCount:(NSUInteger)maxEntryCount
+{
+    if(processName == nil || processID == 0 || timestamp == nil || maxEntryCount == 0)
+        return nil;
+    
+    NSString *processIDString = [NSString stringWithFormat:@"%u", (unsigned int)processID];
+    NSTimeInterval timestampInterval = [timestamp timeIntervalSince1970];
+    timestampInterval += 2.0; // Give it a buffer of 2 seconds - some log entries might have been outputted during the crash
+    NSString *timestampString = [NSString stringWithFormat:@"%u", (unsigned int)timestampInterval];
+    
+	NSMutableArray *logEntries = [NSMutableArray array];
+    
+	aslmsg q = asl_new(ASL_TYPE_QUERY);
+	asl_set_query(q, ASL_KEY_SENDER, [processName UTF8String], ASL_QUERY_OP_EQUAL);
+    asl_set_query(q, ASL_KEY_PID, [processIDString UTF8String], ASL_QUERY_OP_EQUAL);
+    asl_set_query(q, ASL_KEY_TIME, [timestampString UTF8String], ASL_QUERY_OP_LESS_EQUAL | ASL_QUERY_OP_NUMERIC);
+    
+	aslresponse r = asl_search(NULL, q);
+	aslmsg m = NULL;
+    
+	while (NULL != (m = aslresponse_next(r)))
+	{
+		const char *value = asl_get(m, ASL_KEY_SENDER);
+		NSString *sender = (value != NULL) ? [NSString stringWithUTF8String:value] : @"";
+        
+        value = asl_get(m, ASL_KEY_PID);
+		NSString *processID = (value != NULL) ? [NSString stringWithUTF8String:value] : @"";
+        
+        value = asl_get(m, ASL_KEY_MSG);
+		NSString *message = (value != NULL) ? [NSString stringWithUTF8String:value] : @"";
+        
+        value = asl_get(m, "CFLog Local Time");
+		NSString *localizedTime = (value != NULL) ? [NSString stringWithUTF8String:value] : @"";
+        
+        value = asl_get(m, "CFLog Thread");
+		NSString *threadName = (value != NULL) ? [NSString stringWithUTF8String:value] : @"";
+
+		NSString *combinedLogEntry = [NSString stringWithFormat:@"%@ %@[%@:%@] %@", localizedTime, sender, processID, threadName, message];
+        
+		[logEntries addObject:combinedLogEntry];
+	}
+	aslresponse_free(r);
+	asl_free(q);
+    
+    if([logEntries count] > maxEntryCount)
+    {
+        // Select last entries, since they're most recent ones
+        [logEntries removeObjectsInRange:NSMakeRange([logEntries count] - maxEntryCount - 1, maxEntryCount)];
+    }
+    
+    // Reverse the order so that most recent are at the beginning of the array
+    return [[logEntries reverseObjectEnumerator] allObjects];
+}
+
 - (void)_performSendingCrashReports {
   NSMutableDictionary *approvedCrashReports = [NSMutableDictionary dictionaryWithDictionary:[[NSUserDefaults standardUserDefaults] dictionaryForKey: kApprovedCrashReports]];
   
@@ -507,6 +569,18 @@ NSString *BWQuincyLocalize(NSString *stringToken) {
         continue;
       }
       
+      if(self.appendConsoleLogsToDescription) {
+          // Collect console log of this process up to the time of crash.
+          // Limit the number of entries to self.consoleLogMaxCount to avoid sending too much data.
+          NSArray *logEntries = [self _fetchConsoleLogEntriesForProcessName:report.processInfo.processName
+                                                                  processID:report.processInfo.processID
+                                                                  timestamp:report.systemInfo.timestamp
+                                                              maxEntryCount:self.consoleLogMaxCount];
+          
+          description = [description stringByAppendingString:@"\n\n"];
+          description = [description stringByAppendingString:[logEntries componentsJoinedByString:@"\n"]];
+      }
+
       NSString *crashLogString = [PLCrashReportTextFormatter stringValueForCrashReport:report withTextFormat:PLCrashReportTextFormatiOS];
       
       if ([report.applicationInfo.applicationVersion compare:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"]] == NSOrderedSame) {


### PR DESCRIPTION
Hi,

Haven't tested this code yet, but what do you think about the idea of sending console logs as "description" of each crash, including those log entries which were produced just before the crash happened?
