### PR TITLE
process crash files from any Library dirctory

### DIFF
--- a/client/Mac/BWQuincyManager.m
+++ b/client/Mac/BWQuincyManager.m
@@ -168,18 +168,23 @@
     return NO;
   }
   
-  NSArray* libraryDirectories = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, TRUE);
-  // Snow Leopard is having the log files in another location
-  [self searchCrashLogFile:[[libraryDirectories lastObject] stringByAppendingPathComponent:@"Logs/DiagnosticReports"]];
-  if (_crashFile == nil) {
-    [self searchCrashLogFile:[[libraryDirectories lastObject] stringByAppendingPathComponent:@"Logs/CrashReporter"]];
+  NSArray* libraryDirectories = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSAllDomainsMask, TRUE);
+  NSEnumerator *e = [libraryDirectories objectEnumerator];
+  id dir;
+  while (dir = [e nextObject]) {
+    // Snow Leopard is having the log files in another location
+    [self searchCrashLogFile:[dir stringByAppendingPathComponent:@"Logs/DiagnosticReports"]];
     if (_crashFile == nil) {
-      NSString *sandboxFolder = [NSString stringWithFormat:@"/Containers/%@/Data/Library", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"]];
-      if ([[libraryDirectories lastObject] rangeOfString:sandboxFolder].location != NSNotFound) {
-        NSString *libFolderName = [[libraryDirectories lastObject] stringByReplacingOccurrencesOfString:sandboxFolder withString:@""];
-        [self searchCrashLogFile:[libFolderName stringByAppendingPathComponent:@"Logs/DiagnosticReports"]];
+      [self searchCrashLogFile:[dir stringByAppendingPathComponent:@"Logs/CrashReporter"]];
+      if (_crashFile == nil) {
+        NSString *sandboxFolder = [NSString stringWithFormat:@"/Containers/%@/Data/Library", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"]];
+        if ([dir rangeOfString:sandboxFolder].location != NSNotFound) {
+          NSString *libFolderName = [dir stringByReplacingOccurrencesOfString:sandboxFolder withString:@""];
+          [self searchCrashLogFile:[libFolderName stringByAppendingPathComponent:@"Logs/DiagnosticReports"]];
+        }
       }
     }
+    if (_crashFile) break;
   }
   
   if (_crashFile) {


### PR DESCRIPTION
Here is one way to fix #95, which works for me. More ideal would be to consider the most recent crash from all directories, instead of the most recent crash from the first directory with any crashes, but crashes in multiple directories are probably not a common occurrence, and user directories come first:

```
NSAllDomainsMask: (
    "/var/root/Library",
    "/Library",
    "/Network/Library",
    "/System/Library"
)
```
