### PR TITLE
Add support for searching the machine crash directory for system crashes

### DIFF
--- a/client/Mac/BWQuincyManager.m
+++ b/client/Mac/BWQuincyManager.m
@@ -180,6 +180,14 @@
         [self searchCrashLogFile:[libFolderName stringByAppendingPathComponent:@"Logs/DiagnosticReports"]];
       }
     }
+    // Search machine diagnostic reports directory
+    if (_crashFile == nil) {
+      NSArray* libraryDirectories = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSLocalDomainMask, TRUE);
+      [self searchCrashLogFile:[[libraryDirectories lastObject] stringByAppendingPathComponent:@"Logs/DiagnosticReports"]];
+      if (_crashFile == nil) {
+          [self searchCrashLogFile:[[libraryDirectories lastObject] stringByAppendingPathComponent:@"Logs/CrashReporter"]];
+      }
+    }
   }
   
   if (_crashFile) {


### PR DESCRIPTION
This adds support for searching the system directories for crash reports (/Library/Logs/).
