### PR TITLE
Made crashLogTextView non-editable.

### DIFF
--- a/client/Mac/BWQuincyUI.m
+++ b/client/Mac/BWQuincyUI.m
@@ -68,6 +68,14 @@ const CGFloat kDetailsHeight = 285;
 }
 
 
+- (void)awakeFromNib
+{
+	crashLogTextView.editable = NO;
+	crashLogTextView.selectable = NO;
+	crashLogTextView.automaticSpellingCorrectionEnabled = NO;
+}
+
+
 - (void) endCrashReporter {
   [self close];
 }


### PR DESCRIPTION
This fixes a problem where the window would be resized incorrectly after the crash log text was edited.

Steps to reproduce the bug:
1. click the Show Details button
2. delete a few characters in the crashLogTextView
3. click the Hide Details button --> the window doesn't resize itself correctly anymore
Repeating steps 1 and 3 makes things even worse.
