### PR TITLE
Add armv7s to symbolicate script

### DIFF
--- a/server/local/symbolicatecrash.pl
+++ b/server/local/symbolicatecrash.pl
@@ -58,6 +58,7 @@ my %architectures = (
     "ARMV5"  =>  "armv5",
     "ARMV6"  =>  "armv6",
     "ARMV7"  =>  "armv7",
+    "ARMV7S" =>  "armv7s",
 );
 #############################
 


### PR DESCRIPTION
iPhone 5 architecture is now armv7s.
