### PR TITLE
Increase the version string length in a crashlog to 64 characters.

### DIFF
--- a/server/admin/app_versions.php
+++ b/server/admin/app_versions.php
@@ -198,7 +198,7 @@ if ($acceptallapps)
 else
 	echo $bundleidentifier;
 
-echo "</td><td><input type='text' name='version' size='7' maxlength='20'/></td><td><select name='status'>";
+echo "</td><td><input type='text' name='version' size='7' maxlength='64'/></td><td><select name='status'>";
 
 for ($i=0; $i < count($statusversions); $i++)
 {

--- a/server/admin/crashes.php
+++ b/server/admin/crashes.php
@@ -186,7 +186,7 @@ if ($groupid !='') {
             
             echo '<form name="groupmetadata" action="" method="get">';
             echo '<b style="vertical-align: top;">Description:</b><textarea id="description'.$groupid.'" cols="50" rows="2" name="description" class="description" style="margin-left: 10px;">'.$description.'</textarea>';
-            echo '<b style="vertical-align: top; margin-left:20px;">Assigned Fix Version:</b><input style="vertical-align: top; margin-left:10px;" type="text" id="fixversion'.$groupid.'" name="fixversion" size="20" maxlength="20" value="'.$fix.'"/>';
+            echo '<b style="vertical-align: top; margin-left:20px;">Assigned Fix Version:</b><input style="vertical-align: top; margin-left:10px;" type="text" id="fixversion'.$groupid.'" name="fixversion" size="64" maxlength="64" value="'.$fix.'"/>';
             echo "<a href=\"javascript:updateGroupMeta(".$groupid.",'".$bundleidentifier."')\" class='button' style='float: right;'>Update</a>";
          	  echo create_issue($bundleidentifier, currentPageURL());
             echo '</form></td>';

--- a/server/admin/groups.php
+++ b/server/admin/groups.php
@@ -205,7 +205,7 @@ if ($numrows > 0) {
     	echo "-";
     }
         	
-		echo '</td><td><input type="text" id="fixversion'.$groupid.'" name="fixversion" size="20" maxlength="20" value="'.$fix.'"/></td><td><textarea id="description'.$groupid.'" cols="50" rows="2" name="description" class="description">'.$description.'</textarea></td><td>';
+		echo '</td><td><input type="text" id="fixversion'.$groupid.'" name="fixversion" size="64" maxlength="64" value="'.$fix.'"/></td><td><textarea id="description'.$groupid.'" cols="50" rows="2" name="description" class="description">'.$description.'</textarea></td><td>';
     echo "<a href=\"javascript:updateGroupMeta(".$groupid.",'".$bundleidentifier."')\" class='button'>Update</a> ";
 		echo "<a href='actionapi.php?action=downloadcrashid&groupid=".$groupid."' class='button'>Download</a> ";
 		$issuelink = currentPageURL();

--- a/server/database_schema.sql
+++ b/server/database_schema.sql
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS `crash` (
   `bundleidentifier` varchar(250) collate utf8_unicode_ci default NULL,
   `applicationname` varchar(50) collate utf8_unicode_ci default NULL,
   `senderversion` varchar(15) collate utf8_unicode_ci NOT NULL default '',
-  `version` varchar(15) collate utf8_unicode_ci default NULL,
+  `version` varchar(64) collate utf8_unicode_ci default NULL,
   `description` mediumtext collate utf8_unicode_ci,
   `log` text collate utf8_unicode_ci NOT NULL,
   `timestamp` timestamp NOT NULL default CURRENT_TIMESTAMP,
@@ -103,8 +103,8 @@ CREATE TABLE IF NOT EXISTS `crash` (
 CREATE TABLE IF NOT EXISTS `crash_groups` (
   `id` bigint(20) unsigned NOT NULL auto_increment,
   `bundleidentifier` varchar(250) collate utf8_unicode_ci default NULL,
-  `affected` varchar(20) collate utf8_unicode_ci default NULL,
-  `fix` varchar(20) collate utf8_unicode_ci default NULL,
+  `affected` varchar(64) collate utf8_unicode_ci default NULL,
+  `fix` varchar(64) collate utf8_unicode_ci default NULL,
   `pattern` varchar(250) collate utf8_unicode_ci NOT NULL default '',
   `description` text collate utf8_unicode_ci,
   `amount` bigint(20) default '0',
@@ -148,7 +148,7 @@ CREATE TABLE IF NOT EXISTS `symbolicated` (
 CREATE TABLE IF NOT EXISTS `versions` (
   `id` bigint(20) unsigned NOT NULL auto_increment,
   `bundleidentifier` varchar(250) collate utf8_unicode_ci default NULL,
-  `version` varchar(20) collate utf8_unicode_ci default NULL,
+  `version` varchar(64) collate utf8_unicode_ci default NULL,
   `status` int(11) NOT NULL default '0',
   `notify` int(11) NOT NULL default '0',
   PRIMARY KEY  (`id`),


### PR DESCRIPTION
The maximum width for a crashlog's version string is too narrow for me, and perhaps others.

My version string contains a sequential integer, the date and time of the build, and the git branch it was built from.

This fix widens the version string field to 64 characters.
